### PR TITLE
StripeApiFactory

### DIFF
--- a/start.php
+++ b/start.php
@@ -8,8 +8,6 @@ require_once __DIR__ . '/lib/events.php';
 require_once __DIR__ . '/lib/hooks.php';
 require_once __DIR__ . '/lib/page_handlers.php';
 
-elgg_register_event_handler('init', 'system', array(__NAMESPACE__ . '\\StripeApiFactory', 'init'), 1);
-elgg_register_event_handler('shutdown', 'system', array(__NAMESPACE__ . '\\StripeApiFactory', 'shutdown'));
 
 elgg_register_event_handler('init', 'system', __NAMESPACE__ . '\\stripe_init');
 elgg_register_event_handler('pagesetup', 'system', __NAMESPACE__ . '\\stripe_pagesetup');


### PR DESCRIPTION
Where's located the StripeApiFactory method?
Can't be passed an array of elements as callback parameter to the elgg_register_event_handler.
